### PR TITLE
feat: Add L2 regularization (weight decay) support

### DIFF
--- a/etna_core/src/layers.rs
+++ b/etna_core/src/layers.rs
@@ -80,9 +80,13 @@ impl Linear {
     pub fn update(&mut self, optimizer: &mut SGD) {
         for i in 0..self.output_size {
             for j in 0..self.input_size {
-                self.weights[i][j] -= optimizer.learning_rate * self.grad_weights[i][j];
+                // L2 regularization: add lambda * weight to gradient
+                // grad_total = grad_loss + lambda * weight
+                let l2_term = optimizer.weight_decay * self.weights[i][j];
+                self.weights[i][j] -= optimizer.learning_rate * (self.grad_weights[i][j] + l2_term);
                 self.grad_weights[i][j] = 0.0;
             }
+            // Note: We don't apply weight decay to biases (standard practice)
             self.bias[i] -= optimizer.learning_rate * self.grad_bias[i];
             self.grad_bias[i] = 0.0;
         }

--- a/etna_core/src/lib.rs
+++ b/etna_core/src/lib.rs
@@ -43,12 +43,13 @@ impl EtnaModel {
         }
     }
 
-    fn train(&mut self, x: &Bound<'_, PyList>, y: &Bound<'_, PyList>, epochs: usize, lr: f32) -> PyResult<Vec<f32>> {
+    #[pyo3(signature = (x, y, epochs, lr, weight_decay=0.0))]
+    fn train(&mut self, x: &Bound<'_, PyList>, y: &Bound<'_, PyList>, epochs: usize, lr: f32, weight_decay: f32) -> PyResult<Vec<f32>> {
         let x_vec = pylist_to_vec2(x);
         let y_vec = pylist_to_vec2(y);
         
         // Capture the history returned by Rust
-        let history = self.inner.train(&x_vec, &y_vec, epochs, lr);
+        let history = self.inner.train(&x_vec, &y_vec, epochs, lr, weight_decay);
         
         // Return it to Python
         Ok(history)

--- a/etna_core/src/model.rs
+++ b/etna_core/src/model.rs
@@ -59,8 +59,8 @@ impl SimpleNN {
         output
     }
 
-    pub fn train(&mut self, x: &Vec<Vec<f32>>, y: &Vec<Vec<f32>>, epochs: usize, lr: f32) -> Vec<f32> {
-        let mut optimizer = SGD::new(lr);
+    pub fn train(&mut self, x: &Vec<Vec<f32>>, y: &Vec<Vec<f32>>, epochs: usize, lr: f32, weight_decay: f32) -> Vec<f32> {
+        let mut optimizer = SGD::with_weight_decay(lr, weight_decay);
         let mut loss_history = Vec::new(); // Create list
 
         for epoch in 0..epochs {

--- a/etna_core/src/optimizer.rs
+++ b/etna_core/src/optimizer.rs
@@ -1,14 +1,30 @@
 // # Optimizers (SGD, Adam, etc.)
 
-/// Simple Stochastic Gradient Descent (SGD) optimizer
+/// Simple Stochastic Gradient Descent (SGD) optimizer with optional L2 regularization (weight decay)
+/// 
+/// L2 regularization adds a penalty term to the loss function: L_reg = L + (lambda/2) * ||W||^2
+/// The gradient becomes: grad_W = grad_L + lambda * W
+/// This encourages smaller weights and helps prevent overfitting.
 
 pub struct SGD {
     pub learning_rate: f32,
+    pub weight_decay: f32,  // L2 regularization coefficient (lambda)
 }
 
 impl SGD {
     pub fn new(learning_rate: f32) -> Self {
-        SGD { learning_rate }
+        SGD { 
+            learning_rate,
+            weight_decay: 0.0,  // Default: no regularization
+        }
+    }
+
+    /// Create SGD optimizer with L2 regularization (weight decay)
+    pub fn with_weight_decay(learning_rate: f32, weight_decay: f32) -> Self {
+        SGD { 
+            learning_rate, 
+            weight_decay,
+        }
     }
 
     // Update weights and biases in-place
@@ -60,5 +76,18 @@ mod tests {
             expected,
             actual
         );
+    }
+
+    #[test]
+    fn sgd_with_weight_decay_creates_correctly() {
+        let optimizer = SGD::with_weight_decay(0.01, 0.001);
+        assert!((optimizer.learning_rate - 0.01).abs() < 1e-6);
+        assert!((optimizer.weight_decay - 0.001).abs() < 1e-6);
+    }
+
+    #[test]
+    fn sgd_default_has_no_weight_decay() {
+        let optimizer = SGD::new(0.1);
+        assert!((optimizer.weight_decay - 0.0).abs() < 1e-6);
     }
 }


### PR DESCRIPTION
## Summary
Implements L2 regularization (weight decay) to help prevent overfitting in small MLPs.

Closes #21

## Changes

### Rust Core
- **`optimizer.rs`**: Added `weight_decay` field to SGD optimizer with `with_weight_decay()` constructor
- **`layers.rs`**: Modified `Linear::update()` to apply L2 penalty: `grad_total = grad_loss + λ * weight`
- **`model.rs`**: Updated `train()` to accept and pass `weight_decay` parameter
- **`lib.rs`**: Exposed `weight_decay` to Python API with default value `0.0`

### Python API
- **`api.py`**: Added `weight_decay` parameter to `Model.train()` with documentation
- **Bonus fix**: `predict()` now works without arguments after training (caches training data)

## Usage
```python
from etna import Model

model = Model("data.csv", target="label")

# Without regularization (default, backward compatible)
model.train(epochs=100, lr=0.01)

# With L2 regularization
model.train(epochs=100, lr=0.01, weight_decay=0.001)
```

## ScreenShot 
<img width="927" height="917" alt="Screenshot 2026-01-06 004635" src="https://github.com/user-attachments/assets/a69149a1-5695-45aa-b553-428ec83bc865" />

