### PR TITLE
feat: Add Xavier/Kaiming weight initialization

### DIFF
--- a/etna_core/src/layers.rs
+++ b/etna_core/src/layers.rs
@@ -5,8 +5,20 @@ use rand::Rng;
 use crate::optimizer::SGD;
 use serde::{Serialize, Deserialize};
 
+/// Weight initialization strategy
+/// - Xavier (Glorot): For layers followed by Sigmoid/Softmax. std = sqrt(2 / (n_in + n_out))
+/// - Kaiming (He): For layers followed by ReLU/LeakyReLU. std = sqrt(2 / n_in)
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum InitStrategy {
+    /// Xavier/Glorot initialization - best for Sigmoid, Tanh, Softmax
+    Xavier,
+    /// Kaiming/He initialization - best for ReLU, LeakyReLU
+    Kaiming,
+    /// Legacy random initialization (-0.1 to 0.1)
+    Legacy,
+}
+
 /// Fully connected layer: y = Wx + b
-// Linear Layer (implementing forward, backward, and update)
 // Linear Layer (implementing forward, backward, and update)
 
 #[derive(Serialize, Deserialize)]
@@ -21,13 +33,50 @@ pub struct Linear {
 }
 
 impl Linear {
+    /// Create a new Linear layer with legacy initialization (backward compatible)
     pub fn new(input_size: usize, output_size: usize) -> Self {
+        Self::new_with_init(input_size, output_size, InitStrategy::Legacy)
+    }
+
+    /// Create a new Linear layer with specified initialization strategy
+    /// 
+    /// # Arguments
+    /// * `input_size` - Number of input features
+    /// * `output_size` - Number of output features  
+    /// * `init` - Initialization strategy (Xavier, Kaiming, or Legacy)
+    pub fn new_with_init(input_size: usize, output_size: usize, init: InitStrategy) -> Self {
         let mut rng = rand::thread_rng();
         
-        // Initialize weights with small random values (e.g., between -0.1 and 0.1)
-        let weights = (0..output_size)
-            .map(|_| (0..input_size).map(|_| rng.gen_range(-0.1..0.1)).collect())
-            .collect();
+        let weights = match init {
+            InitStrategy::Xavier => {
+                // Xavier/Glorot: std = sqrt(2 / (n_in + n_out))
+                let std = (2.0 / (input_size + output_size) as f32).sqrt();
+                (0..output_size)
+                    .map(|_| {
+                        (0..input_size)
+                            .map(|_| Self::sample_normal(&mut rng) * std)
+                            .collect()
+                    })
+                    .collect()
+            },
+            InitStrategy::Kaiming => {
+                // Kaiming/He: std = sqrt(2 / n_in)
+                let std = (2.0 / input_size as f32).sqrt();
+                (0..output_size)
+                    .map(|_| {
+                        (0..input_size)
+                            .map(|_| Self::sample_normal(&mut rng) * std)
+                            .collect()
+                    })
+                    .collect()
+            },
+            InitStrategy::Legacy => {
+                // Legacy: uniform random between -0.1 and 0.1
+                (0..output_size)
+                    .map(|_| (0..input_size).map(|_| rng.gen_range(-0.1..0.1)).collect())
+                    .collect()
+            },
+        };
             
         let bias = vec![0.0; output_size];
         
@@ -37,6 +86,14 @@ impl Linear {
         let cached_input = vec![];
 
         Linear { weights, bias, input_size, output_size, grad_weights, grad_bias, cached_input }
+    }
+
+    /// Sample from standard normal distribution using Box-Muller transform
+    fn sample_normal<R: Rng>(rng: &mut R) -> f32 {
+        // Box-Muller transform for normal distribution
+        let u1: f32 = rng.gen_range(0.0001..1.0); // Avoid log(0)
+        let u2: f32 = rng.gen_range(0.0..1.0);
+        (-2.0 * u1.ln()).sqrt() * (2.0 * std::f32::consts::PI * u2).cos()
     }
 
     pub fn forward(&mut self, input: &Vec<Vec<f32>>) -> Vec<Vec<f32>> {
@@ -203,6 +260,16 @@ impl Activation {
             },
         }
     }
+
+    /// Get the recommended weight initialization strategy for this activation
+    /// - ReLU/LeakyReLU: Kaiming (He) initialization
+    /// - Sigmoid: Xavier (Glorot) initialization
+    pub fn init_strategy(&self) -> InitStrategy {
+        match self {
+            Activation::ReLU | Activation::LeakyReLU => InitStrategy::Kaiming,
+            Activation::Sigmoid => InitStrategy::Xavier,
+        }
+    }
 }
 
 
@@ -350,5 +417,97 @@ mod tests {
         let sigmoid_output = vec![vec![0.5]];
         let grad = act.backward(&grad_output, &sigmoid_output);
         assert!((grad[0][0] - 0.25).abs() < 1e-6);
+    }
+
+    // Weight initialization tests
+    #[test]
+    fn test_kaiming_init_variance() {
+        // Kaiming init: std = sqrt(2/n_in), variance = 2/n_in
+        let input_size = 100;
+        let output_size = 50;
+        let layer = Linear::new_with_init(input_size, output_size, InitStrategy::Kaiming);
+        
+        // Calculate variance of weights
+        let mut sum = 0.0;
+        let mut sum_sq = 0.0;
+        let count = (input_size * output_size) as f32;
+        
+        for row in &layer.weights {
+            for &w in row {
+                sum += w;
+                sum_sq += w * w;
+            }
+        }
+        
+        let mean = sum / count;
+        let variance = sum_sq / count - mean * mean;
+        let expected_variance = 2.0 / input_size as f32;
+        
+        // Allow 50% tolerance due to random sampling
+        assert!(
+            (variance - expected_variance).abs() < expected_variance * 0.5,
+            "Kaiming variance {} should be close to {}", variance, expected_variance
+        );
+    }
+
+    #[test]
+    fn test_xavier_init_variance() {
+        // Xavier init: std = sqrt(2/(n_in + n_out)), variance = 2/(n_in + n_out)
+        let input_size = 100;
+        let output_size = 50;
+        let layer = Linear::new_with_init(input_size, output_size, InitStrategy::Xavier);
+        
+        // Calculate variance of weights
+        let mut sum = 0.0;
+        let mut sum_sq = 0.0;
+        let count = (input_size * output_size) as f32;
+        
+        for row in &layer.weights {
+            for &w in row {
+                sum += w;
+                sum_sq += w * w;
+            }
+        }
+        
+        let mean = sum / count;
+        let variance = sum_sq / count - mean * mean;
+        let expected_variance = 2.0 / (input_size + output_size) as f32;
+        
+        // Allow 50% tolerance due to random sampling
+        assert!(
+            (variance - expected_variance).abs() < expected_variance * 0.5,
+            "Xavier variance {} should be close to {}", variance, expected_variance
+        );
+    }
+
+    #[test]
+    fn test_legacy_init_range() {
+        // Legacy init: uniform between -0.1 and 0.1
+        let layer = Linear::new_with_init(50, 30, InitStrategy::Legacy);
+        
+        for row in &layer.weights {
+            for &w in row {
+                assert!(w >= -0.1 && w <= 0.1, "Legacy weight {} out of range", w);
+            }
+        }
+    }
+
+    #[test]
+    fn test_activation_init_strategy() {
+        assert_eq!(Activation::ReLU.init_strategy(), InitStrategy::Kaiming);
+        assert_eq!(Activation::LeakyReLU.init_strategy(), InitStrategy::Kaiming);
+        assert_eq!(Activation::Sigmoid.init_strategy(), InitStrategy::Xavier);
+    }
+
+    #[test]
+    fn test_linear_new_uses_legacy() {
+        // Linear::new() should use legacy initialization for backward compatibility
+        let layer = Linear::new(10, 5);
+        
+        for row in &layer.weights {
+            for &w in row {
+                assert!(w >= -0.1 && w <= 0.1, "Default init weight {} out of range", w);
+            }
+        }
     }
 }

--- a/etna_core/src/model.rs
+++ b/etna_core/src/model.rs
@@ -1,5 +1,5 @@
 // Model training/prediction logic
-use crate::layers::{Linear, Activation, Softmax};
+use crate::layers::{Linear, Activation, Softmax, InitStrategy};
 use crate::loss_function::{cross_entropy, mse};
 use crate::optimizer::SGD;
 use serde::{Serialize, Deserialize};
@@ -28,11 +28,18 @@ impl SimpleNN {
     pub fn new(input_dim: usize, hidden_dim: usize, output_dim: usize, task_code: usize, activation: Activation) -> Self {
         let task_type = if task_code == 1 { TaskType::Regression } else { TaskType::Classification };
         
+        // Use appropriate initialization based on activation function:
+        // - linear1 is followed by the activation, so use its recommended init
+        // - linear2 is followed by Softmax (classification) or nothing (regression)
+        //   For Softmax, Xavier is appropriate; for regression output, Xavier is also fine
+        let hidden_init = activation.init_strategy();
+        let output_init = InitStrategy::Xavier;
+        
         Self {
-            linear1: Linear::new(input_dim, hidden_dim),
+            linear1: Linear::new_with_init(input_dim, hidden_dim, hidden_init),
             activation,
-            linear2: Linear::new(hidden_dim, output_dim),
-            task_type, // 0 = Classification, 1 = Regression
+            linear2: Linear::new_with_init(hidden_dim, output_dim, output_init),
+            task_type,
             input_cache: vec![],
             hidden_cache: vec![],
             logits_cache: vec![],


### PR DESCRIPTION
## Summary
Implements Xavier (Glorot) and Kaiming (He) weight initialization within the `Linear` layer to prevent vanishing/exploding gradients.

Closes #32

## Changes

### Rust Core (`etna_core/src/layers.rs`)
- Added `InitStrategy` enum with three options:
  - `Xavier`: std = √(2 / (n_in + n_out)) - best for Sigmoid/Softmax
  - `Kaiming`: std = √(2 / n_in) - best for ReLU/LeakyReLU
  - `Legacy`: uniform random [-0.1, 0.1] - backward compatible
- Added `Linear::new_with_init(input_size, output_size, init)` method
- Added `Activation::init_strategy()` to get recommended init for each activation
- `Linear::new()` still uses legacy init for backward compatibility

### Model (`etna_core/src/model.rs`)
- Updated `SimpleNN::new()` to use appropriate initialization during construction:
  - `linear1`: Uses activation's recommended init (Kaiming for ReLU, Xavier for Sigmoid)
  - `linear2`: Uses Xavier (followed by Softmax/output layer)

### Python API (`etna/api.py`)
- Fixed `predict()` to work without arguments after training (caches training data)

## Initialization Formulas
| Strategy | Formula | Best For |
|----------|---------|----------|
| Kaiming (He) | std = √(2/n_in) | ReLU, LeakyReLU |
| Xavier (Glorot) | std = √(2/(n_in + n_out)) | Sigmoid, Softmax |

## Tests Added
- `test_kaiming_init_variance`: Verifies Kaiming variance ≈ 2/n_in
- `test_xavier_init_variance`: Verifies Xavier variance ≈ 2/(n_in + n_out)
- `test_legacy_init_range`: Verifies legacy weights in [-0.1, 0.1]
- `test_activation_init_strategy`: Verifies correct strategy per activation
- `test_linear_new_uses_legacy`: Ensures backward compatibility

## Test Results
- ✅ 27 Rust tests passed
- ✅ 37 Python tests passed

## Screenshot
<img width="953" height="890" alt="image" src="https://github.com/user-attachments/assets/1998701a-c826-4280-98be-82af0037dbfd" />
