### PR TITLE
Handle unseen categorical values using explicit __UNK__ token

### DIFF
--- a/etna/preprocessing.py
+++ b/etna/preprocessing.py
@@ -67,7 +67,11 @@ class Preprocessor:
 
 
             vals = series.fillna(mode_val).astype(str).values
-            unique_vals = np.unique(vals)
+            unique_vals = pd.Series(vals).unique().tolist()
+
+            if "__UNK__" not in unique_vals:
+                unique_vals.append("__UNK__")
+
 
 
 
@@ -80,8 +84,17 @@ class Preprocessor:
                  https://scikit-learn.org/stable/modules/generated/sklearn.preprocessing.OneHotEncoder.html
             '''                 
             one_hot = np.zeros((len(vals), len(mapping)))
+            
+
+
+            unk_index = mapping["__UNK__"]
+
             for i, v in enumerate(vals):
-                one_hot[i, mapping[v]] = 1.0
+                index = mapping.get(v, unk_index)
+                one_hot[i, index] = 1.0
+
+
+
 
             X_processed.append(one_hot)
 
@@ -137,9 +150,12 @@ class Preprocessor:
 
             # Implemented One-Hot Encoding for these columns - transform phase( Second point of the issue covered here)
             one_hot = np.zeros((len(vals), len(mapping)))
+            unk_index = mapping["__UNK__"]
+
             for i, v in enumerate(vals):
-                if v in mapping:
-                    one_hot[i, mapping[v]] = 1.0
+                index = mapping.get(v, unk_index)
+                one_hot[i, index] = 1.0
+
 
             X_processed.append(one_hot)
 


### PR DESCRIPTION
## Fixes
Closes: #55   <!-- replace with the issue number you opened -->

## Type of Change
- [x] Bug fix

## Description
This PR fixes a silent inference bug in the preprocessing pipeline where unseen categorical values were previously encoded as all-zero vectors.

An explicit `__UNK__` category is now added during training for categorical features, and unseen values during inference are consistently routed to this reserved token. This prevents silent degradation of model predictions, ensures stable input dimensions, and maintains persistence safety across save/load cycles.

## How Has This Been Tested?
- [x] **Manual Testing**:  
  - Tested the preprocessing logic locally without the Rust backend.
  - Verified that unseen categorical values during inference are mapped to the `__UNK__` one-hot column.
  - Confirmed that input dimensions remain stable.
  - Verified consistent behavior after serializing and restoring state using `get_state()` / `set_state()`.

## Screenshots / Logs
Attached local test logs demonstrating correct handling of unseen categories and stable feature dimensions.

## Contribution Context
- [x] I am contributing through the SWOC program.
