### PR TITLE
refactor: remove global dead_code suppression and clean up unused items#52

### DIFF
--- a/etna_core/src/layers.rs
+++ b/etna_core/src/layers.rs
@@ -11,8 +11,6 @@ pub enum InitStrategy {
     Xavier,
     /// Kaiming/He initialization - best for ReLU, LeakyReLU
     Kaiming,
-    /// Legacy random initialization (-0.1 to 0.1)
-    Legacy,
 }
 
 /// Fully connected layer: y = Wx + b
@@ -27,10 +25,6 @@ pub struct Linear {
 
 impl Linear {
     /// Create a new Linear layer with legacy initialization (backward compatible)
-    pub fn new(input_size: usize, output_size: usize) -> Self {
-        Self::new_with_init(input_size, output_size, InitStrategy::Legacy)
-    }
-
     /// Create a new Linear layer with specified initialization strategy
     /// 
     /// # Arguments
@@ -64,13 +58,7 @@ impl Linear {
                     })
                     .collect()
             },
-            InitStrategy::Legacy => {
-                // Legacy: uniform random between -0.1 and 0.1
-                (0..output_size)
-                    // UPDATED: Use random_range() (replacing gen_range)
-                    .map(|_| (0..input_size).map(|_| rng.random_range(-0.1..0.1)).collect())
-                    .collect()
-            },
+            
         };
             
         // Initialize gradients as 0.0
@@ -459,17 +447,6 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_legacy_init_range() {
-        // Legacy init: uniform between -0.1 and 0.1
-        let layer = Linear::new_with_init(50, 30, InitStrategy::Legacy);
-        
-        for row in &layer.weights {
-            for &w in row {
-                assert!(w >= -0.1 && w <= 0.1, "Legacy weight {} out of range", w);
-            }
-        }
-    }
 
     #[test]
     fn test_activation_init_strategy() {
@@ -478,15 +455,4 @@ mod tests {
         assert_eq!(Activation::Sigmoid.init_strategy(), InitStrategy::Xavier);
     }
 
-    #[test]
-    fn test_linear_new_uses_legacy() {
-        // Linear::new() should use legacy initialization for backward compatibility
-        let layer = Linear::new(10, 5);
-        
-        for row in &layer.weights {
-            for &w in row {
-                assert!(w >= -0.1 && w <= 0.1, "Default init weight {} out of range", w);
-            }
-        }
-    }
 }

--- a/etna_core/src/lib.rs
+++ b/etna_core/src/lib.rs
@@ -1,6 +1,5 @@
 // Rust-Python bridge (pyo3)
 
-#![allow(dead_code)]
 
 mod model;
 mod layers;

--- a/etna_core/src/utils.rs
+++ b/etna_core/src/utils.rs
@@ -1,53 +1,8 @@
 // # Utility functions (Matrix ops, initialization)
 
 
-/// Converts class indices (e.g., 2, 0, 1) into one-hot vectors.
-pub fn one_hot_encode(labels: &Vec<usize>, num_classes: usize) -> Vec<Vec<f32>> {
-    labels
-        .iter()
-        .map(|&label| {
-            let mut row = vec![0.0; num_classes];
-            row[label] = 1.0;
-            row
-        })
-        .collect()
-}
 
-/// Transposes a matrix (Vec<Vec<f32>>)
-pub fn transpose(matrix: &Vec<Vec<f32>>) -> Vec<Vec<f32>> {
-    if matrix.is_empty() {
-        return vec![];
-    }
 
-    let rows = matrix.len();
-    let cols = matrix[0].len();
 
-    (0..cols)
-        .map(|j| (0..rows).map(|i| matrix[i][j]).collect())
-        .collect()
-}
 
-/// Returns vector of predicted class indices from probabilities
-pub fn argmax_rows(matrix: &Vec<Vec<f32>>) -> Vec<usize> {
-    matrix
-        .iter()
-        .map(|row| {
-            row.iter()
-                .enumerate()
-                .max_by(|a, b| a.1.partial_cmp(b.1).unwrap())
-                .map(|(i, _)| i)
-                .unwrap_or(0)
-        })
-        .collect()
-}
 
-/// Calculates accuracy between predicted and true labels
-pub fn accuracy(preds: &Vec<usize>, labels: &Vec<usize>) -> f32 {
-    let correct = preds
-        .iter()
-        .zip(labels)
-        .filter(|(p, l)| p == l)
-        .count();
-
-    correct as f32 / preds.len() as f32
-}


### PR DESCRIPTION
Fixes
Closes: #52

Type of Change
[ ] Bug fix

[ ] New feature

[x] Documentation / Refactor

[ ] Math / Logic correction

Description
Removed the global #![allow(dead_code)] suppression from lib.rs and cleaned up the resulting warnings to improve code quality and maintainability.

Specific changes:

lib.rs: Removed the global warning suppression.

layers.rs: Removed the unused InitStrategy::Legacy variant, the deprecated Linear::new constructor, and the associated legacy initialization logic. Also removed tests that depended on these deprecated features.

utils.rs: Deleted unused helper functions (one_hot_encode, transpose, argmax_rows, accuracy) and their corresponding documentation.

How Has This Been Tested?
[x] Unit Tests: Ran pytest suite; confirmed 37/37 tests passed.

[ ] Manual Testing: Verified logic through a dummy training loop.

[x] Integration: Ran cargo check and confirmed the build is now 100% clean with no warnings or errors.

Screenshots / Logs
Rust Verification (Clean Build):
<img width="1173" height="97" alt="Screenshot 2026-01-15 145841" src="https://github.com/user-attachments/assets/4e7fbe30-7372-41c5-8fb5-0c2bb7cdc3d8" />
Python Verification (Tests Passed):
<img width="1472" height="351" alt="Screenshot 2026-01-15 145944" src="https://github.com/user-attachments/assets/c416dc1c-44b6-42df-b33c-20400b122aeb" />
Contribution Context
[x] I am contributing through the SWOC program.