### PR TITLE
feat: Validation Split & MLflow Tracking (fixes #22)

### DIFF
--- a/etna/api.py
+++ b/etna/api.py
@@ -32,6 +32,7 @@ class Model:
         self.target = target
         self.df = load_data(file_path)
         self.loss_history = []
+        self.val_loss_history = []
 
         # --- SEED LOGIC ---
         self.seed = seed
@@ -67,6 +68,34 @@ class Model:
         # Cached transformed data for persistence-safe prediction
         self._cached_X = None
 
+    def _calculate_validation_loss(self, X_val, y_val):
+        """
+        Calculate validation loss using the Rust model's forward pass.
+
+        Args:
+            X_val: Validation features (numpy array).
+            y_val: Validation targets (numpy array).
+
+        Returns:
+            float: Validation loss value.
+        """
+        preds = self.rust_model.forward(X_val)
+
+        if self.task_type == "classification":
+            # Cross-entropy loss
+            loss = 0.0
+            for p_row, y_row in zip(preds, y_val):
+                for p_val, y_true in zip(p_row, y_row):
+                    loss += -y_true * np.log(p_val + 1e-7)
+            return loss / len(preds)
+        else:
+            # MSE loss
+            loss = 0.0
+            for p_row, y_row in zip(preds, y_val):
+                for p_val, y_true in zip(p_row, y_row):
+                    loss += (p_val - y_true) ** 2
+            return loss / len(preds)
+
     def train(
         self,
         epochs: int = 100,
@@ -77,6 +106,7 @@ class Model:
         early_stopping: bool = False,
         patience: int = 10,
         restore_best: bool = True,
+        validation_split: float = 0.2,
     ):
         """
         Train the model.
@@ -90,11 +120,18 @@ class Model:
             early_stopping: If True, stop training when loss stops improving.
             patience: Number of epochs with no improvement before stopping.
             restore_best: If True, restore weights from the best epoch.
+            validation_split: Fraction of data to use for validation (0.0 to 1.0).
+                              Set to 0.0 to disable validation. Default: 0.2.
         """
         if _etna_rust is None:
             raise ImportError(
                 "Rust core is not available. Please build the Rust extension "
                 "before calling model.train()."
+            )
+
+        if not (0.0 <= validation_split < 1.0):
+            raise ValueError(
+                f"validation_split must be >= 0.0 and < 1.0, got {validation_split}"
             )
 
         print("[*] Preprocessing data...")
@@ -104,7 +141,32 @@ class Model:
         X = np.ascontiguousarray(X, dtype=np.float32)
         y = np.ascontiguousarray(y, dtype=np.float32)
 
-        # Cache training data for predict() without arguments
+        # --- Validation Split ---
+        X_val = None
+        y_val = None
+        if validation_split > 0.0:
+            n_samples = X.shape[0]
+            n_val = max(1, int(n_samples * validation_split))
+
+            # Shuffle indices before splitting (use seed for reproducibility)
+            rng = np.random.default_rng(self.seed)
+            indices = rng.permutation(n_samples)
+
+            val_indices = indices[:n_val]
+            train_indices = indices[n_val:]
+
+            X_val = np.ascontiguousarray(X[val_indices], dtype=np.float32)
+            y_val = np.ascontiguousarray(y[val_indices], dtype=np.float32)
+            X_train = np.ascontiguousarray(X[train_indices], dtype=np.float32)
+            y_train = np.ascontiguousarray(y[train_indices], dtype=np.float32)
+
+            print(f"[*] Data split: {len(train_indices)} training samples, {len(val_indices)} validation samples")
+        else:
+            X_train = X
+            y_train = y
+            print("[*] Validation disabled (validation_split=0.0)")
+
+        # Cache full data for predict() without arguments
         self._cached_X = X
 
         self.input_dim = X.shape[1]
@@ -114,7 +176,6 @@ class Model:
         if optimizer_lower not in ['sgd', 'adam']:
             raise ValueError(f"Unsupported optimizer '{optimizer}'. Choose 'sgd' or 'adam'.")
 
-        # LOGICAL FIX: Only initialize if model doesn't exist
         # Only initialize if model doesn't exist (supports incremental training)
         if self.rust_model is None:
             print(f"[*] Initializing Rust Core [In: {self.input_dim}, Out: {self.output_dim}]...")
@@ -138,15 +199,24 @@ class Model:
         # Create tqdm progress bar
         pbar = tqdm(total=epochs, desc="Training", unit="epoch")
         
+        # Storage for per-epoch validation losses computed inside callback
+        epoch_val_losses = []
+
         # Callback function that Rust calls after each epoch
         def progress_callback(epoch, total, loss):
             pbar.update(1)
-            pbar.set_description(f"Loss: {loss:.4f}")
+            # Compute validation loss if validation data is available
+            if X_val is not None and y_val is not None:
+                val_loss = self._calculate_validation_loss(X_val, y_val)
+                epoch_val_losses.append(val_loss)
+                pbar.set_description(f"Loss: {loss:.4f} | Val Loss: {val_loss:.4f}")
+            else:
+                pbar.set_description(f"Loss: {loss:.4f}")
         
         # Single Rust call - training loop stays in Rust for performance
         new_losses = self.rust_model.train(
-            X,
-            y,
+            X_train,
+            y_train,
             epochs,
             lr,
             batch_size,
@@ -160,6 +230,7 @@ class Model:
         
         pbar.close()
         self.loss_history.extend(new_losses)
+        self.val_loss_history.extend(epoch_val_losses)
         print("[+] Training complete!")
 
     def predict(self, data_path: str = None):
@@ -267,6 +338,8 @@ class Model:
                     mlflow.log_param("target_column", self.target)
                     for epoch, loss in enumerate(self.loss_history):
                         mlflow.log_metric("loss", loss, step=epoch)
+                    for epoch, val_loss in enumerate(self.val_loss_history):
+                        mlflow.log_metric("val_loss", val_loss, step=epoch)
                     mlflow.log_artifact(path)
                     mlflow.log_artifact(preprocessor_path)
                 print("Model saved & tracked!")
@@ -323,6 +396,7 @@ class Model:
         self.file_path = None
         self.df = None
         self.loss_history = []
+        self.val_loss_history = []
 
         print("[+] Model loaded successfully!")
         return self

--- a/etna_core/src/lib.rs
+++ b/etna_core/src/lib.rs
@@ -100,6 +100,12 @@ impl EtnaModel {
         Ok(history)
     }
 
+    /// Expose raw forward pass outputs (pre-argmax) for validation loss computation.
+    fn forward(&mut self, x: PyReadonlyArray2<'_, f32>) -> PyResult<Vec<Vec<f32>>> {
+        let x_vec = ndarray_to_vec2(x);
+        Ok(self.inner.forward(&x_vec))
+    }
+
     fn predict(&mut self, x: PyReadonlyArray2<'_, f32>) -> PyResult<Vec<f32>> {
         let x_vec = ndarray_to_vec2(x);
         Ok(self.inner.predict(&x_vec))

--- a/tests/test_tqdm_progress.py
+++ b/tests/test_tqdm_progress.py
@@ -65,7 +65,7 @@ def test_tqdm_progress_bar():
                 
                 # Create model and train with progress bar
                 model = etna.api.Model("dummy.csv", "target", task_type="classification")
-                model.train(epochs=5, lr=0.01)
+                model.train(epochs=5, lr=0.01, validation_split=0.0)
                 
                 # Verify train was called only ONCE (all epochs in Rust)
                 assert mock_model.train.call_count == 1, f"Expected 1 train call, got {mock_model.train.call_count}"

--- a/tests/test_validation_split.py
+++ b/tests/test_validation_split.py
@@ -1,0 +1,234 @@
+"""
+Test script to verify validation split and MLflow val_loss tracking.
+Uses mocking to bypass Rust backend compilation requirement.
+"""
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch, call
+import numpy as np
+import pytest
+
+# Add project root to path
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+
+def _create_mock_setup(n_samples=100, n_features=4, output_dim=2, task_type="classification"):
+    """Helper to create a mock Rust backend and model for testing."""
+    mock_etna_rust = MagicMock()
+    mock_model = MagicMock()
+
+    # Simulate train() that calls progress_callback each epoch
+    def mock_train(
+        X, y, epochs, lr, batch_size, weight_decay, optimizer,
+        early_stopping=False, patience=10, restore_best=True,
+        progress_callback=None,
+    ):
+        losses = []
+        for epoch in range(epochs):
+            loss = 0.5 - (epoch * 0.01)
+            losses.append(loss)
+            if progress_callback:
+                progress_callback(epoch, epochs, loss)
+        return losses
+
+    # Simulate forward() returning raw predictions
+    def mock_forward(X_val):
+        n = X_val.shape[0] if hasattr(X_val, 'shape') else len(X_val)
+        if task_type == "classification":
+            # Return softmax-like outputs
+            return [[0.7, 0.3] for _ in range(n)]
+        else:
+            # Return regression predictions
+            return [[0.5] for _ in range(n)]
+
+    mock_model.train.side_effect = mock_train
+    mock_model.forward.side_effect = mock_forward
+    mock_etna_rust.EtnaModel.return_value = mock_model
+
+    return mock_etna_rust, mock_model
+
+
+def _get_patched_model(mock_etna_rust, task_type="classification", n_samples=100):
+    """Create a patched Model instance for testing."""
+    import importlib
+    import etna.api
+    importlib.reload(etna.api)
+    etna.api._etna_rust = mock_etna_rust
+
+    mock_preprocessor = MagicMock()
+    X_data = np.random.randn(n_samples, 4).astype(np.float32)
+    if task_type == "classification":
+        y_data = np.zeros((n_samples, 2), dtype=np.float32)
+        y_data[np.arange(n_samples), np.random.randint(0, 2, n_samples)] = 1.0
+    else:
+        y_data = np.random.randn(n_samples, 1).astype(np.float32)
+
+    mock_preprocessor.fit_transform.return_value = (X_data, y_data)
+    mock_preprocessor.output_dim = 2 if task_type == "classification" else 1
+
+    with patch.object(etna.api, 'load_data') as mock_load:
+        mock_load.return_value = MagicMock()
+        with patch.object(etna.api, 'Preprocessor') as mock_prep:
+            mock_prep.return_value = mock_preprocessor
+            model = etna.api.Model("dummy.csv", "target", task_type=task_type, seed=42)
+
+    return model, etna.api
+
+
+# ---- Tests ----
+
+
+def test_validation_split_default():
+    """Verify val_loss_history is populated with default validation_split=0.2."""
+    mock_etna_rust, mock_model = _create_mock_setup()
+    model, api_mod = _get_patched_model(mock_etna_rust)
+    model.train(epochs=5, lr=0.01)
+
+    assert len(model.loss_history) == 5, f"Expected 5 loss entries, got {len(model.loss_history)}"
+    assert len(model.val_loss_history) == 5, f"Expected 5 val_loss entries, got {len(model.val_loss_history)}"
+    # forward() should have been called once per epoch for validation
+    assert mock_model.forward.call_count == 5, f"Expected 5 forward() calls, got {mock_model.forward.call_count}"
+
+
+def test_validation_split_zero_disables_validation():
+    """Verify no validation when validation_split=0.0."""
+    mock_etna_rust, mock_model = _create_mock_setup()
+    model, api_mod = _get_patched_model(mock_etna_rust)
+    model.train(epochs=5, lr=0.01, validation_split=0.0)
+
+    assert len(model.loss_history) == 5
+    assert len(model.val_loss_history) == 0, "val_loss_history should be empty when validation is disabled"
+    assert mock_model.forward.call_count == 0, "forward() should not be called when validation is disabled"
+
+
+def test_validation_split_data_sizes():
+    """Verify correct train/val split sizes are passed to Rust."""
+    n_samples = 100
+    validation_split = 0.2
+    mock_etna_rust, mock_model = _create_mock_setup(n_samples=n_samples)
+    model, api_mod = _get_patched_model(mock_etna_rust, n_samples=n_samples)
+    model.train(epochs=3, lr=0.01, validation_split=validation_split)
+
+    # Check that Rust train() received the training portion only
+    train_call_args = mock_model.train.call_args
+    X_train_passed = train_call_args[0][0]  # First positional arg
+    expected_train_size = n_samples - max(1, int(n_samples * validation_split))
+
+    assert X_train_passed.shape[0] == expected_train_size, (
+        f"Expected {expected_train_size} training samples, got {X_train_passed.shape[0]}"
+    )
+
+
+def test_validation_split_invalid_values():
+    """Verify error for invalid validation_split values."""
+    mock_etna_rust, _ = _create_mock_setup()
+    model, api_mod = _get_patched_model(mock_etna_rust)
+
+    with pytest.raises(ValueError, match="validation_split must be"):
+        model.train(epochs=3, lr=0.01, validation_split=1.0)
+
+    # Re-create model since the previous call may have modified state
+    model2, _ = _get_patched_model(mock_etna_rust)
+    with pytest.raises(ValueError, match="validation_split must be"):
+        model2.train(epochs=3, lr=0.01, validation_split=-0.1)
+
+
+def test_validation_split_regression():
+    """Verify validation works for regression tasks."""
+    mock_etna_rust, mock_model = _create_mock_setup(task_type="regression")
+    model, api_mod = _get_patched_model(mock_etna_rust, task_type="regression")
+    model.train(epochs=5, lr=0.01, validation_split=0.3)
+
+    assert len(model.val_loss_history) == 5
+    # All val_loss values should be finite numbers
+    for vl in model.val_loss_history:
+        assert np.isfinite(vl), f"Validation loss should be finite, got {vl}"
+
+
+def test_training_loop_stays_in_rust():
+    """Verify that train() is called exactly once (loop stays in Rust)."""
+    mock_etna_rust, mock_model = _create_mock_setup()
+    model, api_mod = _get_patched_model(mock_etna_rust)
+    model.train(epochs=10, lr=0.01)
+
+    assert mock_model.train.call_count == 1, (
+        f"Expected 1 train call (all epochs in Rust), got {mock_model.train.call_count}"
+    )
+
+
+def test_seed_reproducibility():
+    """Verify that the same seed produces the same val split."""
+    mock_etna_rust1, mock_model1 = _create_mock_setup()
+    model1, _ = _get_patched_model(mock_etna_rust1)
+    model1.train(epochs=3, lr=0.01, validation_split=0.2)
+    val_losses_1 = list(model1.val_loss_history)
+
+    mock_etna_rust2, mock_model2 = _create_mock_setup()
+    model2, _ = _get_patched_model(mock_etna_rust2)
+    model2.train(epochs=3, lr=0.01, validation_split=0.2)
+    val_losses_2 = list(model2.val_loss_history)
+
+    # Same seed=42 should give same val_loss values
+    assert val_losses_1 == val_losses_2, "Same seed should produce identical validation losses"
+
+
+def test_val_loss_in_save_model_mlflow():
+    """Verify save_model() logs val_loss to MLflow."""
+    mock_etna_rust, mock_model = _create_mock_setup()
+    model, api_mod = _get_patched_model(mock_etna_rust)
+    model.train(epochs=3, lr=0.01)
+
+    # Mock MLflow
+    mock_mlflow = MagicMock()
+    mock_run = MagicMock()
+    mock_mlflow.start_run.return_value.__enter__ = MagicMock(return_value=mock_run)
+    mock_mlflow.start_run.return_value.__exit__ = MagicMock(return_value=False)
+
+    # Mock rust_model.save to not actually write files
+    model.rust_model.save = MagicMock()
+    model.preprocessor = MagicMock()
+    model.preprocessor.get_state.return_value = {"test": True}
+    model._cached_X = np.array([[1, 2]])
+
+    import builtins
+    original_open = builtins.open
+
+    with patch('builtins.open', MagicMock()):
+        with patch.dict('sys.modules', {'mlflow': mock_mlflow}):
+            with patch('os.environ.get', return_value=None):
+                model.save_model(
+                    path="test_model.json",
+                    run_name="test_run",
+                    mlflow_tracking_uri="http://localhost:5000"
+                )
+
+    # Check that val_loss was logged
+    log_metric_calls = mock_mlflow.log_metric.call_args_list
+    val_loss_calls = [c for c in log_metric_calls if c[0][0] == "val_loss"]
+    assert len(val_loss_calls) == 3, f"Expected 3 val_loss log calls, got {len(val_loss_calls)}"
+
+
+if __name__ == "__main__":
+    test_validation_split_default()
+    print("✅ test_validation_split_default PASSED")
+
+    test_validation_split_zero_disables_validation()
+    print("✅ test_validation_split_zero_disables_validation PASSED")
+
+    test_validation_split_data_sizes()
+    print("✅ test_validation_split_data_sizes PASSED")
+
+    test_validation_split_invalid_values()
+    print("✅ test_validation_split_invalid_values PASSED")
+
+    test_validation_split_regression()
+    print("✅ test_validation_split_regression PASSED")
+
+    test_training_loop_stays_in_rust()
+    print("✅ test_training_loop_stays_in_rust PASSED")
+
+    test_seed_reproducibility()
+    print("✅ test_seed_reproducibility PASSED")
+
+    print("\n🎉 All validation split tests passed!")


### PR DESCRIPTION
## Fixes
Closes: #22

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation / Refactor
- [ ] Math / Logic correction

## Description
Implemented validation split and MLflow tracking for monitoring model generalization performance.

**Changes:**
- Added `validation_split: float = 0.2` parameter to `Model.train()` method
- Split data into training and validation sets after preprocessing (shuffled, seed-reproducible)
- Compute validation loss per-epoch inside the existing Rust `progress_callback` — **training loop stays entirely in Rust**, preserving optimizer state and avoiding FFI overhead
- Added `_calculate_validation_loss()` method supporting both classification (cross-entropy) and regression (MSE)
- Extended Rust bindings with `forward()` method to expose raw model outputs for validation loss calculation
- Updated `save_model()` to log both `loss` and `val_loss` metrics to MLflow with epoch steps
- Added input validation for `validation_split` parameter range
- Stored `val_loss_history` on model instance, initialized in `__init__()` and `load()`

**Key architectural decisions (addressing PR #62 feedback):**
- Training loop remains **100% in Rust** — `rust_model.train()` called exactly once
- Optimizer state (Adam moments, SGD) is **never reset** between epochs
- Validation loss computed in the existing `progress_callback` (no extra FFI overhead)
- Data shuffled before split using `np.random.default_rng(seed)` for reproducibility

**Result:** MLflow dashboard now displays overlapping train/validation loss curves for monitoring overfitting and generalization.

## How Has This Been Tested?
- [x] **Unit Tests:** Created and ran `test_validation_split.py` with 8 tests covering classification, regression, edge cases, seed reproducibility, and MLflow logging
- [x] **Smoke Testing:** Verified end-to-end with mock datasets — progress bar shows both Train Loss and Val Loss
- [x] **Integration:** Confirmed Rust core `forward()` method works correctly with Python API
- [x] **Existing Tests:** All 46 pytest tests pass (38 existing + 8 new, zero regressions)

## Screenshots / Logs

<!-- Add your screenshots here -->

 
<img width="1004" height="221" alt="image" src="https://github.com/user-attachments/assets/a124f93e-7675-4f0c-8770-e81a763ce191" />


<img width="729" height="188" alt="image" src="https://github.com/user-attachments/assets/0d5b2e9c-e89b-4df0-9a40-459542e5a7e6" />


<img width="731" height="184" alt="image" src="https://github.com/user-attachments/assets/de54d9cb-56c9-475a-9600-65908653422f" />


## Contribution Context
- [x] I am contributing through the SWOC program.
